### PR TITLE
Update runtime to 6.10 and more

### DIFF
--- a/org.kde.vvave.json
+++ b/org.kde.vvave.json
@@ -2,7 +2,7 @@
     "id": "org.kde.vvave",
     "rename-icon": "vvave",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "vvave",
     "finish-args": [
@@ -34,26 +34,6 @@
                         "type": "anitya",
                         "project-id": 20545,
                         "url-template": "https://github.com/nemtrif/utfcpp/archive/refs/tags/v$version.tar.gz"
-                    }
-                }
-            ]
-        },
-        {
-            "config-opts": [
-                "-DBUILD_TESTING=OFF"
-            ],
-            "name": "taglib",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://taglib.github.io/releases/taglib-2.1.1.tar.gz",
-                    "sha256": "3716d31f7c83cbf17b67c8cf44dd82b2a2f17e6780472287a16823e70305ddba",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 1982,
-                        "stable-only": true,
-                        "url-template": "https://taglib.github.io/releases/taglib-$version.tar.gz"
                     }
                 }
             ]


### PR DESCRIPTION
- Update runtime to 6.10
- Also, drop the taglib module that is provided by the runtime.

Fixes: https://github.com/flathub/org.kde.vvave/issues/64